### PR TITLE
feat: add minor hall stamp requirement

### DIFF
--- a/web/src/components/reward/RewardsAvailabilityList.tsx
+++ b/web/src/components/reward/RewardsAvailabilityList.tsx
@@ -78,6 +78,8 @@ export const RewardsAvailabilityList: FC = () => {
           <ul className="mb-2 ml-4 list-disc">{premiumRewards}</ul>
         </p>
       )}
+
+      <p>{t("currentRallyBlock.minorHallInfo")}</p>
     </>
   );
 };

--- a/web/src/components/reward/SubmitDrawer.tsx
+++ b/web/src/components/reward/SubmitDrawer.tsx
@@ -33,8 +33,12 @@ interface SubmitDrawerProps {
 
 export const SubmitDrawer: FC<SubmitDrawerProps> = ({ open, setOpen }) => {
   const { t } = useTranslation();
-  const { isStandardRewardObtainable, isPremiumRewardObtainable } =
-    useRewardAvailability();
+  const {
+    isStandardRewardObtainable,
+    isPremiumRewardObtainable,
+    isAnyStampFromMinorHall,
+    stampCount,
+  } = useRewardAvailability();
   const navigate = useNavigate();
   const {
     isPending,
@@ -102,9 +106,15 @@ export const SubmitDrawer: FC<SubmitDrawerProps> = ({ open, setOpen }) => {
             <p className="flex items-center gap-2 py-2 font-bold text-red-600">
               <TicketX className="inline-block shrink-0" size={24} />
               <span>
-                {t("submitNotAllowed", {
-                  stamps: standardRewardMinStampsRequirement,
-                })}
+                {stampCount < standardRewardMinStampsRequirement &&
+                  t("submitNotAllowed.count", {
+                    stamps: standardRewardMinStampsRequirement,
+                  })}
+                {!isAnyStampFromMinorHall &&
+                  " " +
+                    t("submitNotAllowed.minorHall", {
+                      stamps: standardRewardMinStampsRequirement,
+                    })}
               </span>
             </p>
           )}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -236,7 +236,7 @@
   "qrcode": "QR Code",
   "rally.1": "16 artists take part in this rally around VTubers",
   "rally.2": "After making a purchase (minimum 2€) from a participant booth, scan the QR code to get a stamp",
-  "rally.3": "Once you've collected {{minimumStampsCount}} stamps, head over to Sedeto's booth to get a reward!",
+  "rally.3": "Once you've collected {{minimumStampsCount}} stamps and visited both halls, head over to Sedeto's booth to get a reward!",
   "rally.4": "This year, try to win a holographic card by getting all the stamps!",
   "rally.5": "Once you get your reward, enter the draw to win a shikishi from Sedeto!",
   "rally.6": "You can replay as many times as you like while rewards last!",
@@ -326,7 +326,8 @@
     "getToStandardCardReward_other": "Only {{count}} more stamps to win one, two, or three <1><icon/>exclusive cards</1>.",
     "getToPremiumCardReward_zero": "You've finished everything! You can now try your luck to get <1><icon/>a special holographic card</1>.",
     "getToPremiumCardReward_one": "One more stamp for a chance to get <1><icon/>a special holographic card</1>!",
-    "getToPremiumCardReward_other": "Only {{count}} more stamps for a chance to get <1><icon/>a special holographic card</1>!"
+    "getToPremiumCardReward_other": "Only {{count}} more stamps for a chance to get <1><icon/>a special holographic card</1>!",
+    "scanFromMinorHall": "<strong>Warning</strong>: To validate your rally, you have to scan a stamp from a booth located in hall 5A. <em>Why? To ensure equity between both halls.</em>"
   },
   "stampValidated": "Stamp added!",
   "stampsCount_one": "{{count}} stamp collected, go to {{maxCount}}!",
@@ -349,9 +350,13 @@
     "submitError": "Sorry, the submit hasn't gone through, please reach to us at Arqo & Sedeto's booth.",
     "submitAction": "Submit",
     "submitDrawerTitle": "Submit your rally",
-    "submitDrawerDescription": "Send your stamps to the server to claim your rewards!"
+    "submitDrawerDescription": "Send your stamps to the server to claim your rewards!",
+    "minorHallInfo": "To ensure fairness between halls, one of the stamps must come from a booth located in Hall 5A."
   },
-  "submitNotAllowed": "You have to scan at least {{stamps}} stamps.",
+  "submitNotAllowed": {
+    "count": "You have to scan at least {{stamps}} stamps.",
+    "minorHall": "You have to scan a stamp from Hall 5A."
+  },
   "submitStamps": "Submit your collected stamps here!",
   "submitTerms": "This code is valid for the entire duration of the convention, you may get your reward at any day of the convention, if you want to try to get cards that are out-of-stock for the day.",
   "submittedAgo": "Submitted {{time}}",

--- a/web/src/i18n/fr.json
+++ b/web/src/i18n/fr.json
@@ -236,7 +236,7 @@
   "qrcode": "QR Code",
   "rally.1": "16 artistes participent à ce rally autour des VTubers",
   "rally.2": "Après un achat (minimum 2€) chez un stand participant, scannez le tampon QR Code",
-  "rally.3": "Une fois {{minimumStampsCount}} tampons obtenus, rendez-vous au stand de Sedeto pour récupérer une récompense !",
+  "rally.3": "Une fois {{minimumStampsCount}} tampons obtenus en ayant visité les deux halls, rendez-vous au stand de Sedeto pour récupérer une récompense !",
   "rally.4": "Cette année, tentez votre chance pour une carte holographique en obtenant tous les tampons !",
   "rally.5": "Après avoir récupéré une récompense, participez au concours pour gagner un shikishi de Sedeto !",
   "rally.6": "Vous pouvez rejouer autant de fois que vous le souhaitez ! Dans la limite des stocks disponibles et dans la bonne humeur",
@@ -326,7 +326,8 @@
     "getToStandardCardReward_other": "Plus que {{count}} tampons pour remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
     "getToPremiumCardReward_zero": "Vous avez tout fini ! Vous pouvez dès maintenant tenter votre chance pour obtenir <1><icon/>une carte spéciale holographique</1>.",
     "getToPremiumCardReward_one": "Un dernier tampon pour une chance d'obtenir <1><icon/>une carte spéciale holographique</1> !",
-    "getToPremiumCardReward_other": "Plus que {{count}} tampons pour une chance d'obtenir <1><icon/>une carte spéciale holographique</1> !"
+    "getToPremiumCardReward_other": "Plus que {{count}} tampons pour une chance d'obtenir <1><icon/>une carte spéciale holographique</1> !",
+    "scanFromMinorHall": "<strong>Attention</strong>, pour valider votre rally, scannez un tampon d'un stand du hall 5A. <em>Pourquoi ? Pour assurer l'équité entre les deux halls.</em>"
   },
   "stampValidated": "Tampon validé !",
   "stampsCount_one": "{{count}} tampon collecté sur {{maxCount}} !",
@@ -349,9 +350,13 @@
     "submitError": "Désolé, votre rally n'a pas été soumis, merci de vous rapprocher des équipes du stand Arqo & Sedeto.",
     "submitAction": "Soumettre",
     "submitDrawerTitle": "Soumettre votre rally",
-    "submitDrawerDescription": "Envoyez vos tampons au serveur pour pouvoir obtenir vos lots !"
+    "submitDrawerDescription": "Envoyez vos tampons au serveur pour pouvoir obtenir vos lots !",
+    "minorHallInfo": "Pour assurer l'équité entre les halls, un des tampons doit provenir d'un stand situé dans le hall 5A."
   },
-  "submitNotAllowed": "Vous devez scanner au moins {{stamps}} tampons.",
+  "submitNotAllowed": {
+    "count": "Vous devez scanner au moins {{stamps}} tampons.",
+    "minorHall": "Vous devez scanner un tampon du hall 5A."
+  },
   "submitStamps": "Soumettez vos tampons collectés ici !",
   "submitTerms": "Ce code ne périme pas, vous pouvez récupérer votre récompense n'importe quel jour de la convention pour récupérer des cartes qui ne sont plus en stock pour la journée.",
   "submittedAgo": "Soumis {{time}}",

--- a/web/src/lib/hooks/useRewardAvailability.ts
+++ b/web/src/lib/hooks/useRewardAvailability.ts
@@ -1,20 +1,35 @@
+import { useMemo } from "react";
+
 import {
   premiumRewardMinStampsRequirement,
   standardRewardMinStampsRequirement,
 } from "@/lib/consts.ts";
 import { useCollectedStamps } from "@/lib/hooks/useCollectedStamps.ts";
+import { useStandists } from "@/lib/hooks/useStandists.ts";
 
 export const useRewardAvailability = () => {
   const { data: stamps } = useCollectedStamps();
+  const { data: standists } = useStandists();
+
+  const minorHallStandistsIds = useMemo(() => {
+    const minorHallStandists = standists.filter((standist) => {
+      return standist.hall === "5A";
+    });
+    return new Set(minorHallStandists.map((standist) => standist.userId));
+  }, [standists]);
 
   const stampCount = stamps?.length ?? 0;
+  const isAnyStampFromMinorHall =
+    stamps?.some((stamp) => minorHallStandistsIds.has(stamp.standistId)) ??
+    false;
   const isStandardRewardObtainable =
-    stampCount >= standardRewardMinStampsRequirement;
+    isAnyStampFromMinorHall && stampCount >= standardRewardMinStampsRequirement;
   const isPremiumRewardObtainable =
-    stampCount >= premiumRewardMinStampsRequirement;
+    isAnyStampFromMinorHall && stampCount >= premiumRewardMinStampsRequirement;
 
   return {
     stampCount,
+    isAnyStampFromMinorHall,
     isStandardRewardObtainable,
     isPremiumRewardObtainable,
   } as const;

--- a/web/src/routes/_rallyists/stamp.tsx
+++ b/web/src/routes/_rallyists/stamp.tsx
@@ -1,6 +1,6 @@
 import { useConfetti } from "@stevent-team/react-party";
 import { createFileRoute } from "@tanstack/react-router";
-import { TicketCheck } from "lucide-react";
+import { MessageSquareWarning, TicketCheck } from "lucide-react";
 import { LegacyRef, Suspense, useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -17,8 +17,8 @@ import {
   premiumRewardMinStampsRequirement,
   standardRewardMinStampsRequirement,
 } from "@/lib/consts.ts";
-import { useCollectedStamps } from "@/lib/hooks/useCollectedStamps.ts";
 import { useRallySubmissions } from "@/lib/hooks/useRallySubmissions.ts";
+import { useRewardAvailability } from "@/lib/hooks/useRewardAvailability.ts";
 import { useStandist } from "@/lib/hooks/useStandist.ts";
 import {
   orangeTriangleEmphasis,
@@ -52,16 +52,16 @@ function Stamp() {
 
   const standist = useStandist(data.standistId);
 
-  const { data: stamps } = useCollectedStamps();
+  const { isAnyStampFromMinorHall, stampCount, isStandardRewardObtainable } =
+    useRewardAvailability();
 
-  const stampCount = stamps?.length ?? 1;
+  const showSubmitButton = isStandardRewardObtainable;
 
-  const showSubmitButton = stampCount >= standardRewardMinStampsRequirement;
-
-  const launchConfetti = [
-    standardRewardMinStampsRequirement,
-    premiumRewardMinStampsRequirement,
-  ].includes(stampCount);
+  const launchConfetti =
+    [
+      standardRewardMinStampsRequirement,
+      premiumRewardMinStampsRequirement,
+    ].includes(stampCount) && isAnyStampFromMinorHall;
 
   const { data: submissions } = useRallySubmissions();
 
@@ -105,18 +105,33 @@ function Stamp() {
         </div>
         <RallyProgressBar />
         <p className="text-gray-700">
-          <Trans
-            t={t}
-            i18nKey="stampGoals.getToStandardCardReward"
-            components={orangeTriangleEmphasis}
-            values={{
-              count: Math.max(
-                standardRewardMinStampsRequirement - stampCount,
-                0,
-              ),
-            }}
-          />
-          <br className="mb-2" />
+          {!isAnyStampFromMinorHall &&
+            stampCount >= standardRewardMinStampsRequirement - 2 && (
+              <span className="mb-2 block border-4 border-amber-700 p-2">
+                <MessageSquareWarning className="mb-2 text-amber-700" />
+                <Trans
+                  t={t}
+                  i18nKey="stampGoals.scanFromMinorHall"
+                  components={{ strong: <strong />, em: <em /> }}
+                />
+              </span>
+            )}
+          {(isAnyStampFromMinorHall || !isStandardRewardObtainable) && (
+            <>
+              <Trans
+                t={t}
+                i18nKey="stampGoals.getToStandardCardReward"
+                components={orangeTriangleEmphasis}
+                values={{
+                  count: Math.max(
+                    standardRewardMinStampsRequirement - stampCount,
+                    0,
+                  ),
+                }}
+              />
+              <br className="mb-2" />
+            </>
+          )}
           <Trans
             t={t}
             i18nKey="stampGoals.getToPremiumCardReward"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a requirement that at least one collected stamp must be from a booth located in hall 5A to claim a reward.
- **Enhancements**
	- Updated user interface and messages to clearly indicate the new hall 5A stamp requirement and minimum stamp count.
	- Introduced conditional error messages based on stamp count and hall 5A stamp presence during submission.
	- Added informational text about the hall 5A stamp requirement in multiple components.
	- Enhanced reward availability logic to reflect new stamp and hall criteria.
	- Added a warning message when no stamp from hall 5A is detected and stamp count is insufficient.
- **Bug Fixes**
	- Improved error handling and validation for stamp submission, ensuring requirements are enforced.
- **Documentation**
	- Updated English and French instructions and messages to clarify the new rules and requirements for reward eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->