### PR TITLE
feat: add website for standists

### DIFF
--- a/appwrite.json
+++ b/appwrite.json
@@ -126,6 +126,14 @@
           "default": null
         },
         {
+          "key": "website",
+          "type": "string",
+          "required": false,
+          "array": false,
+          "size": 256,
+          "default": null
+        },
+        {
           "key": "boothNumber",
           "type": "string",
           "required": true,

--- a/shared-lib/src/models/Standist.ts
+++ b/shared-lib/src/models/Standist.ts
@@ -16,6 +16,7 @@ export interface Standist {
   twitter?: string;
   instagram?: string;
   twitch?: string;
+  website?: string;
 
   geometry?: Polygon["coordinates"];
 }
@@ -28,4 +29,4 @@ export interface StandistDocument
 }
 
 export const standistIndexes =
-  "&userId, name, hall, boothNumber, description, image, twitter, instagram, twitch";
+  "&userId, name, hall, boothNumber, description, image, twitter, instagram, twitch, website";

--- a/web/src/components/artists/ArtistPresentation.tsx
+++ b/web/src/components/artists/ArtistPresentation.tsx
@@ -71,6 +71,11 @@ export const ArtistPresentation: FC<{ artistId: string }> = ({ artistId }) => {
         {artist.twitch && (
           <ExternalLink href={artist.twitch}>Twitch</ExternalLink>
         )}
+        {artist.website && (
+          <ExternalLink href={artist.website}>
+            {URL.parse(artist.website)?.hostname}
+          </ExternalLink>
+        )}
       </div>
       <QRCodeLink />
     </div>

--- a/web/src/components/routes/standists/StandistsProfilePage.tsx
+++ b/web/src/components/routes/standists/StandistsProfilePage.tsx
@@ -14,7 +14,7 @@ import { useUser } from "@/lib/hooks/useUser.ts";
 
 export type StandistsEditProfileForm = Pick<
   Standist,
-  "description" | "twitch" | "twitter" | "instagram"
+  "description" | "twitch" | "twitter" | "instagram" | "website" | "name"
 >;
 
 const StandistsProfilePage = () => {
@@ -27,10 +27,12 @@ const StandistsProfilePage = () => {
 
   const methods = useForm<StandistsEditProfileForm>({
     defaultValues: {
+      name: artist?.name,
       description: artist?.description,
       twitter: artist?.twitter,
       instagram: artist?.instagram,
       twitch: artist?.twitch,
+      website: artist?.website,
     },
   });
 
@@ -83,6 +85,17 @@ const StandistsProfilePage = () => {
       <Header>{t("profile.title")}</Header>
       <form className={"flex flex-col gap-4"} onSubmit={handleSubmit(onSubmit)}>
         <div className={"flex flex-col"}>
+          <label htmlFor={"name"}>{t("standName")}</label>
+          <InputField
+            type={"text"}
+            name={"name"}
+            placeholder={"Stand"}
+            required={true}
+            register={register}
+            errors={errors["name"]}
+          />
+        </div>
+        <div className={"flex flex-col"}>
           <label htmlFor={"description"}>{t("description")}</label>
           <InputField
             inputType={"textarea"}
@@ -134,6 +147,18 @@ const StandistsProfilePage = () => {
             required={false}
             register={register}
             errors={errors["twitch"]}
+          />
+        </div>
+
+        <div className={"flex flex-col"}>
+          <label htmlFor={"website"}>{t("website")}</label>
+          <InputField
+            type={"url"}
+            name={"website"}
+            placeholder={"https://stand.com"}
+            required={false}
+            register={register}
+            errors={errors["website"]}
           />
         </div>
 

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -148,6 +148,22 @@
     },
     "title": "Contest"
   },
+  "currentRallyBlock": {
+    "availableRewardPresentation_one": "By submitting now, you will be entitled to the following reward:",
+    "availableRewardPresentation_other": "By submitting now, you will be entitled to the following rewards:",
+    "evenMoreClassicCards": "A second special draw for even more exclusive cards",
+    "holographicCard": "A chance to get an exclusive card in its holographic version!",
+    "minorHallInfo": "To ensure fairness between halls, one of the stamps must come from a booth located in Hall 5A.",
+    "oneOrMoreClassicCards": "One, two, or three exclusive cards",
+    "premiumCardRewardPresentation": "By continuing to the <1><icon/>next tier</1> at {{stamps}} stamps, you also unlock the following rewards:",
+    "resetDisclaimer": "Once the stamps are submitted, you'll start from scratch to reach the tiers.",
+    "standardCardRewardPresentation": "By reaching the <1><icon/>first tier</1> at {{stamps}} stamps, you will be entitled to the following reward:",
+    "submitAction": "Submit",
+    "submitDrawerDescription": "Send your stamps to the server to claim your rewards!",
+    "submitDrawerTitle": "Submit your rally",
+    "submitError": "Sorry, the submit hasn't gone through, please reach to us at Arqo & Sedeto's booth.",
+    "title": "Ongoing rally"
+  },
   "description": "Description",
   "email": "Email",
   "error": "An error occurred",
@@ -188,46 +204,46 @@
   },
   "map": "Map",
   "mapLegend": {
-    "title": "Legend",
-    "green": "Stamped booths are shown with a <1>green</1> outline.",
     "blue": "Not visited yet booths are shown with a <1>blue</1> outline.",
+    "green": "Stamped booths are shown with a <1>green</1> outline.",
+    "title": "Legend",
     "yellow": "The booth where you can get rewards is shown with a <1>yellow</1> name."
   },
   "mapWillSoonBeAvailable": "The map will soon be available!",
   "name": "Name",
   "no": "No",
-  "notifications": {
-    "permissionNotGrantedToast": {
-      "title": "Notification permission",
-      "description": "Go to the web browser settings to allow notifications."
-    },
-    "notificationSentToast": {
-      "title": "Notification sent",
-      "description": "It may take a few minutes to reach all users."
-    },
-    "fcmError": {
-      "title": "Cannot toggle notifications",
-      "description": "A connection to the notification backend could not be established."
-    },
-    "nudge": {
-      "title": "Stay informed",
-      "description": "If you agree, a friendly notification will remind you to go to the rally's shikishi contest. The prize is a free watercolor commission from Sedeto!",
-      "button": "Enable notifications",
-      "done": "Notifications enabled!",
-      "reminder": "You can disable them later in the Settings menu.",
-      "ignore": "Ignore and don't show this again"
-    },
-    "templates": {
-      "contest": {
-        "title": "VTuber Rally contest begins soon!",
-        "text": "Head to Sedeto's booth (H6, R687) to register for a chance to win a commission from Sedeto."
-      }
-    }
-  },
   "notImplemented": "Not implemented yet",
   "notLoggedIn": "You're not logged in",
   "notRedeemed": "Unredeemed submissions",
   "notRedeemedDescription": "This submission has not been redeemed yet.",
+  "notifications": {
+    "fcmError": {
+      "description": "A connection to the notification backend could not be established.",
+      "title": "Cannot toggle notifications"
+    },
+    "notificationSentToast": {
+      "description": "It may take a few minutes to reach all users.",
+      "title": "Notification sent"
+    },
+    "nudge": {
+      "button": "Enable notifications",
+      "description": "If you agree, a friendly notification will remind you to go to the rally's shikishi contest. The prize is a free watercolor commission from Sedeto!",
+      "done": "Notifications enabled!",
+      "ignore": "Ignore and don't show this again",
+      "reminder": "You can disable them later in the Settings menu.",
+      "title": "Stay informed"
+    },
+    "permissionNotGrantedToast": {
+      "description": "Go to the web browser settings to allow notifications.",
+      "title": "Notification permission"
+    },
+    "templates": {
+      "contest": {
+        "text": "Head to Sedeto's booth (H6, R687) to register for a chance to win a commission from Sedeto.",
+        "title": "VTuber Rally contest begins soon!"
+      }
+    }
+  },
   "optionalName": "Name (optional)",
   "password": "Password",
   "profile": {
@@ -262,34 +278,34 @@
       "title": "4pm Exclusive Contest"
     },
     "disclaimer": "Rewards are available while supplies last.",
+    "navbarTitle": "Rewards",
+    "pageTitle": "Rewards",
     "rally": {
-      "collectedStamps_zero": "No stamps collected",
+      "button": "View my submissions",
       "collectedStamps_one": "{{count}} stamp collected",
       "collectedStamps_other": "{{count}} stamps collected",
-      "button": "View my submissions",
+      "collectedStamps_zero": "No stamps collected",
       "description": "Collect stamps to get one or more exclusive rewards.",
-      "title": "Stamp Rally",
       "faq": {
+        "replay": {
+          "description": "You can play as many times as you want! However, it is forbidden to play with multiple devices simultaneously.",
+          "title": "Can you do a rally again?"
+        },
         "rewards": {
           "title": "What are the rewards?"
         },
-        "submissions": {
-          "title": "How do I claim the prizes?",
-          "description.1": "To get one or more prizes depending on the tier reached, submit your rally using the button below.",
-          "description.2": "After submission, go to the organizer's booth (Arqo & Sedeto, Hall 6, R687) to collect your prize on site!"
-        },
         "stamps": {
-          "title": "How do I get stamps?",
-          "description": "To get a stamp, buy a product at a participating booth and ask for the rally's QR code. Scan it using the button at the bottom right of the application! <em>The minimum purchase amount is 2€. Maximum one stamp per artist.</em>"
+          "description": "To get a stamp, buy a product at a participating booth and ask for the rally's QR code. Scan it using the button at the bottom right of the application! <em>The minimum purchase amount is 2€. Maximum one stamp per artist.</em>",
+          "title": "How do I get stamps?"
         },
-        "replay": {
-          "title": "Can you do a rally again?",
-          "description": "You can play as many times as you want! However, it is forbidden to play with multiple devices simultaneously."
+        "submissions": {
+          "description.1": "To get one or more prizes depending on the tier reached, submit your rally using the button below.",
+          "description.2": "After submission, go to the organizer's booth (Arqo & Sedeto, Hall 6, R687) to collect your prize on site!",
+          "title": "How do I claim the prizes?"
         }
-      }
-    },
-    "pageTitle": "Rewards",
-    "navbarTitle": "Rewards"
+      },
+      "title": "Stamp Rally"
+    }
   },
   "rules": "Rules",
   "rules.1": "The rally will be completely digital and won't need any 4G, since you loaded it once. The access link will be there and on the booth.",
@@ -327,38 +343,23 @@
     "summary": "Stamp details"
   },
   "stampGoals": {
-    "getToStandardCardReward_zero": "Congrats! You can now win one, two, or three <1><icon/>exclusive cards</1>.",
-    "getToStandardCardReward_one": "One more stamp before you win one, two, or three <1><icon/>exclusive cards</1>.",
-    "getToStandardCardReward_other": "Only {{count}} more stamps to win one, two, or three <1><icon/>exclusive cards</1>.",
-    "getToPremiumCardReward_zero": "You've finished everything! You can now try your luck to get <1><icon/>a special holographic card</1>.",
     "getToPremiumCardReward_one": "One more stamp for a chance to get <1><icon/>a special holographic card</1>!",
     "getToPremiumCardReward_other": "Only {{count}} more stamps for a chance to get <1><icon/>a special holographic card</1>!",
+    "getToPremiumCardReward_zero": "You've finished everything! You can now try your luck to get <1><icon/>a special holographic card</1>.",
+    "getToStandardCardReward_one": "One more stamp before you win one, two, or three <1><icon/>exclusive cards</1>.",
+    "getToStandardCardReward_other": "Only {{count}} more stamps to win one, two, or three <1><icon/>exclusive cards</1>.",
+    "getToStandardCardReward_zero": "Congrats! You can now win one, two, or three <1><icon/>exclusive cards</1>.",
     "scanFromMinorHall": "<strong>Warning</strong>: To validate your rally, you have to scan a stamp from a booth located in hall 5A. <em>Why? To ensure equity between both halls.</em>"
   },
   "stampValidated": "Stamp added!",
   "stampsCount_one": "{{count}} stamp collected, go to {{maxCount}}!",
   "stampsCount_other": "{{count}} stamps collected, go to {{maxCount}}!",
   "stand": "{{name}}'s stand",
+  "standName": "Booth name",
   "standistSpace": "Standist space",
   "submission": "Submission {{id}}",
   "submissions": "Submissions",
   "submissionsGoesHere": "When you finish the rally, you will find information here about claiming your rewards!",
-  "currentRallyBlock": {
-    "title": "Ongoing rally",
-    "availableRewardPresentation_one": "By submitting now, you will be entitled to the following reward:",
-    "availableRewardPresentation_other": "By submitting now, you will be entitled to the following rewards:",
-    "standardCardRewardPresentation": "By reaching the <1><icon/>first tier</1> at {{stamps}} stamps, you will be entitled to the following reward:",
-    "premiumCardRewardPresentation": "By continuing to the <1><icon/>next tier</1> at {{stamps}} stamps, you also unlock the following rewards:",
-    "oneOrMoreClassicCards": "One, two, or three exclusive cards",
-    "evenMoreClassicCards": "A second special draw for even more exclusive cards",
-    "holographicCard": "A chance to get an exclusive card in its holographic version!",
-    "resetDisclaimer": "Once the stamps are submitted, you'll start from scratch to reach the tiers.",
-    "submitError": "Sorry, the submit hasn't gone through, please reach to us at Arqo & Sedeto's booth.",
-    "submitAction": "Submit",
-    "submitDrawerTitle": "Submit your rally",
-    "submitDrawerDescription": "Send your stamps to the server to claim your rewards!",
-    "minorHallInfo": "To ensure fairness between halls, one of the stamps must come from a booth located in Hall 5A."
-  },
   "submitNotAllowed": {
     "count": "You have to scan at least {{stamps}} stamps.",
     "minorHall": "You have to scan a stamp from Hall 5A."

--- a/web/src/i18n/fr.json
+++ b/web/src/i18n/fr.json
@@ -148,6 +148,22 @@
     },
     "title": "Concours"
   },
+  "currentRallyBlock": {
+    "availableRewardPresentation_one": "En soumettant maintenant, vous aurez droit au lot suivant :",
+    "availableRewardPresentation_other": "En soumettant maintenant, vous aurez droit aux lots suivants :",
+    "evenMoreClassicCards": "Un deuxième tirage spécial pour encore plus de cartes",
+    "holographicCard": "Une chance d'obtenir une carte exclusive dans sa version holographique !",
+    "minorHallInfo": "Pour assurer l'équité entre les halls, un des tampons doit provenir d'un stand situé dans le hall 5A.",
+    "oneOrMoreClassicCards": "Une, deux ou trois cartes exclusives",
+    "premiumCardRewardPresentation": "En continuant jusqu'au <1><icon/>palier suivant</1> à {{stamps}} tampons, débloquez en plus les lots suivants :",
+    "resetDisclaimer": "Une fois les tampons soumis, vous repartez de zéro pour atteindre les paliers.",
+    "standardCardRewardPresentation": "En atteignant le <1><icon/>premier palier</1> à {{stamps}} tampons, vous aurez droit au lot suivant :",
+    "submitAction": "Soumettre",
+    "submitDrawerDescription": "Envoyez vos tampons au serveur pour pouvoir obtenir vos lots !",
+    "submitDrawerTitle": "Soumettre votre rally",
+    "submitError": "Désolé, votre rally n'a pas été soumis, merci de vous rapprocher des équipes du stand Arqo & Sedeto.",
+    "title": "Rally en cours"
+  },
   "description": "Description",
   "email": "Email",
   "error": "Une erreur est survenue",
@@ -188,46 +204,46 @@
   },
   "map": "Carte",
   "mapLegend": {
-    "title": "Légende",
-    "green": "Les stands tamponnés sont affichés avec un contour <1>vert</1>.",
     "blue": "Les stands encore à visiter sont affichés avec un contour <1>bleu</1>.",
+    "green": "Les stands tamponnés sont affichés avec un contour <1>vert</1>.",
+    "title": "Légende",
     "yellow": "Le stand où les récompenses sont obtenables est affiché avec un nom <1>jaune</1>."
   },
   "mapWillSoonBeAvailable": "La carte sera bientôt disponible !",
   "name": "Nom",
   "no": "Non",
   "notImplemented": "Pas encore supporté",
-  "notifications": {
-    "permissionNotGrantedToast": {
-      "title": "Permission pour les notifications",
-      "description": "Accédez aux paramètres du navigateur Internet pour autoriser les notifications."
-    },
-    "notificationSentToast": {
-      "title": "Notification envoyée",
-      "description": "Elle peut mettre plusieurs minutes à arriver vers les appareils."
-    },
-    "fcmError": {
-      "title": "Impossible de modifier le paramètre de notifications",
-      "description": "La connexion au serveur de notifications n'a pas pu être établie."
-    },
-    "nudge": {
-      "title": "Soyez à l'affût",
-      "description": "Si vous êtes d'accord, une gentille notification vous rappellera de vous rendre au concours shikishi du rally. À la clé, une commission aquarelle gratuite de Sedeto !",
-      "button": "Activer les notifications",
-      "done": "Notifications activées !",
-      "reminder": "Vous pouvez désactiver ces notifications dans le menu Paramètres.",
-      "ignore": "Ignorer et ne plus montrer ce message"
-    },
-    "templates": {
-      "contest": {
-        "title": "Le concours du Rally VTuber commence bientôt !",
-        "text": "Rendez-vous au stand de Sedeto (H6, R687) pour tenter votre chance de remporter un shikishi personnalisé de Sedeto."
-      }
-    }
-  },
   "notLoggedIn": "Vous n'êtes pas connecté·e",
   "notRedeemed": "Soumissions non validées",
   "notRedeemedDescription": "Cette soumission n'a pas encore été validée.",
+  "notifications": {
+    "fcmError": {
+      "description": "La connexion au serveur de notifications n'a pas pu être établie.",
+      "title": "Impossible de modifier le paramètre de notifications"
+    },
+    "notificationSentToast": {
+      "description": "Elle peut mettre plusieurs minutes à arriver vers les appareils.",
+      "title": "Notification envoyée"
+    },
+    "nudge": {
+      "button": "Activer les notifications",
+      "description": "Si vous êtes d'accord, une gentille notification vous rappellera de vous rendre au concours shikishi du rally. À la clé, une commission aquarelle gratuite de Sedeto !",
+      "done": "Notifications activées !",
+      "ignore": "Ignorer et ne plus montrer ce message",
+      "reminder": "Vous pouvez désactiver ces notifications dans le menu Paramètres.",
+      "title": "Soyez à l'affût"
+    },
+    "permissionNotGrantedToast": {
+      "description": "Accédez aux paramètres du navigateur Internet pour autoriser les notifications.",
+      "title": "Permission pour les notifications"
+    },
+    "templates": {
+      "contest": {
+        "text": "Rendez-vous au stand de Sedeto (H6, R687) pour tenter votre chance de remporter un shikishi personnalisé de Sedeto.",
+        "title": "Le concours du Rally VTuber commence bientôt !"
+      }
+    }
+  },
   "optionalName": "Nom (optionnel)",
   "password": "Mot de passe",
   "profile": {
@@ -262,34 +278,34 @@
       "title": "Concours à 16h"
     },
     "disclaimer": "Les récompenses sont disponibles dans la limite des stocks disponibles.",
+    "navbarTitle": "Récompense",
+    "pageTitle": "Récompenses",
     "rally": {
-      "collectedStamps_zero": "Aucun tampon enregistré",
+      "button": "Voir mes soumissions",
       "collectedStamps_one": "{{count}} tampon enregistré",
       "collectedStamps_other": "{{count}} tampons enregistrés",
-      "button": "Voir mes soumissions",
+      "collectedStamps_zero": "Aucun tampon enregistré",
       "description": "Collectez des tampons et obtenez des récompenses exclusives.",
-      "title": "Stamp Rally",
       "faq": {
+        "replay": {
+          "description": "Vous pouvez rejouer autant de fois que vous voulez ! Il est néanmoins interdit de jouer avec plusieurs appareils en simultané.",
+          "title": "Peut-on refaire un rally ?"
+        },
         "rewards": {
           "title": "Qu'est-ce que je peux gagner ?"
         },
-        "submissions": {
-          "title": "Comment récupérer les lots ?",
-          "description.1": "Pour obtenir un ou des lots selon le palier atteint, soumettez votre rally à l'aide du bouton ci-dessous.",
-          "description.2": "Après envoi, rendez-vous au stand organisateur (Arqo & Sedeto, Hall 6, R687) pour récupérer sur place le lot !"
-        },
         "stamps": {
-          "title": "Comment obtenir des tampons ?",
-          "description": "Pour obtenir un tampon, achetez un produit sur un stand participant et demandez le QR code du rally. Scannez-le à l'aide du bouton situé en bas à droite de l'application ! <em>Le montant minimum d'achat est de 2€. Un tampon par artiste maximum.</em>"
+          "description": "Pour obtenir un tampon, achetez un produit sur un stand participant et demandez le QR code du rally. Scannez-le à l'aide du bouton situé en bas à droite de l'application ! <em>Le montant minimum d'achat est de 2€. Un tampon par artiste maximum.</em>",
+          "title": "Comment obtenir des tampons ?"
         },
-        "replay": {
-          "title": "Peut-on refaire un rally ?",
-          "description": "Vous pouvez rejouer autant de fois que vous voulez ! Il est néanmoins interdit de jouer avec plusieurs appareils en simultané."
+        "submissions": {
+          "description.1": "Pour obtenir un ou des lots selon le palier atteint, soumettez votre rally à l'aide du bouton ci-dessous.",
+          "description.2": "Après envoi, rendez-vous au stand organisateur (Arqo & Sedeto, Hall 6, R687) pour récupérer sur place le lot !",
+          "title": "Comment récupérer les lots ?"
         }
-      }
-    },
-    "pageTitle": "Récompenses",
-    "navbarTitle": "Récompense"
+      },
+      "title": "Stamp Rally"
+    }
   },
   "rules": "Règles",
   "rules.1": "Le rally est entièrement numérique et accessible depuis votre smartphone, la page ne nécessite plus d'internet une fois qu'elle a été chargée une fois. Il sera accessible depuis ce site et depuis un QR code sur le stand de Sedeto (Hall 6, R687).",
@@ -327,38 +343,23 @@
     "summary": "Détails du tampon"
   },
   "stampGoals": {
-    "getToStandardCardReward_zero": "Bravo ! Vous pouvez dès maintenant remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
-    "getToStandardCardReward_one": "Un dernier tampon avant de remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
-    "getToStandardCardReward_other": "Plus que {{count}} tampons pour remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
-    "getToPremiumCardReward_zero": "Vous avez tout fini ! Vous pouvez dès maintenant tenter votre chance pour obtenir <1><icon/>une carte spéciale holographique</1>.",
     "getToPremiumCardReward_one": "Un dernier tampon pour une chance d'obtenir <1><icon/>une carte spéciale holographique</1> !",
     "getToPremiumCardReward_other": "Plus que {{count}} tampons pour une chance d'obtenir <1><icon/>une carte spéciale holographique</1> !",
+    "getToPremiumCardReward_zero": "Vous avez tout fini ! Vous pouvez dès maintenant tenter votre chance pour obtenir <1><icon/>une carte spéciale holographique</1>.",
+    "getToStandardCardReward_one": "Un dernier tampon avant de remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
+    "getToStandardCardReward_other": "Plus que {{count}} tampons pour remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
+    "getToStandardCardReward_zero": "Bravo ! Vous pouvez dès maintenant remporter une, deux ou trois <1><icon/>cartes exclusives</1>.",
     "scanFromMinorHall": "<strong>Attention</strong>, pour valider votre rally, scannez un tampon d'un stand du hall 5A. <em>Pourquoi ? Pour assurer l'équité entre les deux halls.</em>"
   },
   "stampValidated": "Tampon validé !",
   "stampsCount_one": "{{count}} tampon collecté sur {{maxCount}} !",
   "stampsCount_other": "{{count}} tampons collectés sur {{maxCount}} !",
   "stand": "Stand de {{name}}",
+  "standName": "Nom du stand",
   "standistSpace": "Espace standistes",
   "submission": "Soumission {{id}}",
   "submissions": "Soumissions",
   "submissionsGoesHere": "Quand vous aurez terminé votre rally, vous pourrez trouver des informations pour récupérer vos lots !",
-  "currentRallyBlock": {
-    "title": "Rally en cours",
-    "availableRewardPresentation_one": "En soumettant maintenant, vous aurez droit au lot suivant :",
-    "availableRewardPresentation_other": "En soumettant maintenant, vous aurez droit aux lots suivants :",
-    "standardCardRewardPresentation": "En atteignant le <1><icon/>premier palier</1> à {{stamps}} tampons, vous aurez droit au lot suivant :",
-    "premiumCardRewardPresentation": "En continuant jusqu'au <1><icon/>palier suivant</1> à {{stamps}} tampons, débloquez en plus les lots suivants :",
-    "oneOrMoreClassicCards": "Une, deux ou trois cartes exclusives",
-    "evenMoreClassicCards": "Un deuxième tirage spécial pour encore plus de cartes",
-    "holographicCard": "Une chance d'obtenir une carte exclusive dans sa version holographique !",
-    "resetDisclaimer": "Une fois les tampons soumis, vous repartez de zéro pour atteindre les paliers.",
-    "submitError": "Désolé, votre rally n'a pas été soumis, merci de vous rapprocher des équipes du stand Arqo & Sedeto.",
-    "submitAction": "Soumettre",
-    "submitDrawerTitle": "Soumettre votre rally",
-    "submitDrawerDescription": "Envoyez vos tampons au serveur pour pouvoir obtenir vos lots !",
-    "minorHallInfo": "Pour assurer l'équité entre les halls, un des tampons doit provenir d'un stand situé dans le hall 5A."
-  },
   "submitNotAllowed": {
     "count": "Vous devez scanner au moins {{stamps}} tampons.",
     "minorHall": "Vous devez scanner un tampon du hall 5A."

--- a/web/src/lib/hooks/useStandists.ts
+++ b/web/src/lib/hooks/useStandists.ts
@@ -34,6 +34,7 @@ const importStandists = async (): Promise<Standist[]> => {
         twitter,
         instagram,
         twitch,
+        website,
         geometry,
       } = document;
       return {
@@ -47,6 +48,7 @@ const importStandists = async (): Promise<Standist[]> => {
         twitter,
         instagram,
         twitch,
+        website,
         geometry: geometry
           ? (JSON.parse(geometry) as Polygon["coordinates"])
           : undefined,

--- a/web/src/stubs/Standists.ts
+++ b/web/src/stubs/Standists.ts
@@ -17,6 +17,7 @@ export const StandistsFromAppwrite = {
       image: "luyluc.jpg",
       twitter: "@luyluc",
       twitch: null,
+      website: null,
       userId: "66873ba10035780190de",
       geometry:
         "[[[2.521072948439695,48.97144179806506],[2.5210574073065573,48.971419525560094],[2.5210788572159686,48.97141284232384],[2.5210942777049183,48.97143514976122],[2.521072948439695,48.97144179806506]]]",
@@ -39,6 +40,7 @@ export const StandistsFromAppwrite = {
       image: "ElfBoi.jpg",
       twitter: "@elfboi_",
       twitch: "https://www.twitch.tv/elfboiii",
+      website: null,
       userId: "66873ba1003576128a68",
       geometry:
         "[[[2.5204964645312202,48.97143330331653],[2.5204749677508005,48.9714397783159],[2.5204588027131365,48.97141707341959],[2.520479640911759,48.971410478660175],[2.5204964645312202,48.97143330331653]]]",
@@ -61,6 +63,7 @@ export const StandistsFromAppwrite = {
       image: "kea.jpg",
       twitter: "@keaworks",
       twitch: null,
+      website: null,
       userId: "66873ba100357ec09fab",
       geometry:
         "[[[2.5173207024616886,48.96889655740071],[2.5172925099055306,48.96888945302581],[2.517302583234539,48.9688723218666],[2.5173302825651547,48.968879397605434],[2.5173207024616886,48.96889655740071]]]",
@@ -83,6 +86,7 @@ export const StandistsFromAppwrite = {
       image: "minyaa.jpg",
       twitter: "@minyaart",
       twitch: null,
+      website: null,
       userId: "66873ba10035769b944d",
       geometry:
         "[[[2.517192053301926,48.969288533912334],[2.5171665249891078,48.9692821991753],[2.517177308021161,48.96926398778788],[2.5172022509685235,48.969270202172254],[2.517192053301926,48.969288533912334]]]",
@@ -105,6 +109,7 @@ export const StandistsFromAppwrite = {
       image: "asu.jpg",
       twitter: "@Asuinui",
       twitch: null,
+      website: null,
       userId: "66873ba1003566799f36",
       geometry:
         "[[[2.5175230066036534,48.96871010656599],[2.5174881900075263,48.968701461873394],[2.517480358095156,48.968715863429736],[2.5175142530440837,48.96872440480783],[2.5175230066036534,48.96871010656599]]]",
@@ -127,6 +132,7 @@ export const StandistsFromAppwrite = {
       image: "fude.jpg",
       twitter: "@FudepenBrushpen",
       twitch: null,
+      website: null,
       userId: "66873ba100357221ce45",
       geometry:
         "[[[2.517403200412673,48.9690567239692],[2.5173753495575113,48.96904990244249],[2.5173850999965453,48.969033562936005],[2.5174126503814023,48.96904020036618],[2.517403200412673,48.9690567239692]]]",
@@ -149,6 +155,7 @@ export const StandistsFromAppwrite = {
       image: "Elmi.jpg",
       twitter: "@elmi_hikaribi",
       twitch: "https://elmihikaribi.carrd.co/",
+      website: null,
       userId: "66873ba100357fcd48f0",
       geometry:
         "[[[2.517210183234454,48.9695200890458],[2.5172198853155123,48.969503389974506],[2.517191764518202,48.969496314094755],[2.5171819266344073,48.96951260078745],[2.517210183234454,48.9695200890458]]]",
@@ -171,6 +178,7 @@ export const StandistsFromAppwrite = {
       image: "Kawasoft.jpg",
       twitter: "@kawa_soft",
       twitch: null,
+      website: null,
       userId: "66873ba100357c59f3bf",
       geometry:
         "[[[2.5204020705069183,48.9714609695676],[2.5203805755816973,48.97146703120552],[2.520364915203743,48.9714448265957],[2.5203854965097605,48.97143869460862],[2.5204020705069183,48.9714609695676]]]",
@@ -193,6 +201,7 @@ export const StandistsFromAppwrite = {
       image: "VSKR.jpg",
       twitter: "@vskr_art",
       twitch: null,
+      website: null,
       userId: "66873ba100357e9d64bb",
       geometry:
         "[[[2.517231370507858,48.969483691021225],[2.517203056573379,48.969476926156034],[2.517193266218925,48.969493402355795],[2.5172215680844943,48.96950036006055],[2.517231370507858,48.969483691021225]]]",
@@ -215,6 +224,7 @@ export const StandistsFromAppwrite = {
       image: "chisa.jpg",
       twitter: "@littlechisa",
       twitch: null,
+      website: null,
       userId: "66873ba100357a6693e4",
       geometry:
         "[[[2.517332679232595,48.96917969989531],[2.5173052776088127,48.96917279089652],[2.517314928136841,48.96915590164909],[2.5173420759867895,48.96916291523442],[2.517332679232595,48.96917969989531]]]",
@@ -237,6 +247,7 @@ export const StandistsFromAppwrite = {
       image: "cyclic_redundancy.jpg",
       twitter: "@cyclic_red",
       twitch: "https://twitter.com/Ninamo_lcr",
+      website: null,
       userId: "66873ba10035758953e9",
       geometry:
         "[[[2.520436717079974,48.971512647921855],[2.520415278476179,48.97151945871653],[2.5204315961647694,48.971541600264146],[2.5204522717165503,48.971535162033234],[2.520436717079974,48.971512647921855]]]",
@@ -259,6 +270,7 @@ export const StandistsFromAppwrite = {
       image: "sedeto.jpg",
       twitter: "sedeto",
       twitch: null,
+      website: null,
       userId: "66873ba100358581d426",
       geometry:
         "[[[2.517258291549325,48.969373060850785],[2.5172303612801556,48.96936591056877],[2.5172207299427782,48.96938240468438],[2.517248204811011,48.969389339382815],[2.517258291549325,48.969373060850785]]]",
@@ -272,10 +284,14 @@ export const StandistsFromAppwrite = {
   ],
 } satisfies Models.DocumentList<
   Models.Document &
-    Omit<Standist, "publicKey" | "twitch" | "instagram" | "geometry"> & {
+    Omit<
+      Standist,
+      "publicKey" | "twitch" | "instagram" | "website" | "geometry"
+    > & {
       publicKey: string;
       twitch: string | null;
       instagram: string | null;
+      website: string | null;
       geometry: string;
     }
 >;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for artists to include an optional website link in their profiles.
  * Updated artist profile pages to display an external website link if provided.
  * Extended artist profile editing forms to allow input of a website URL and booth name.

* **Translations**
  * Added and reorganised translations for new features, including website and booth name fields, in both English and French.
  * Introduced new translation blocks for rally-related content and improved key ordering for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->