### PR TITLE
HomePage: "Launchpad" à la place de la liste

### DIFF
--- a/web/src/components/HomepageLaunchpad.stories.tsx
+++ b/web/src/components/HomepageLaunchpad.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import HomepageLaunchpad from "@/components/HomepageLaunchpad.tsx";
+import {
+  QRDrawerContextProviderDecorator,
+  RouterDecorator,
+} from "@/lib/decorators.tsx";
+
+const meta = {
+  title: "Rallyist/HomePage/Launchpad",
+  component: HomepageLaunchpad,
+  decorators: [QRDrawerContextProviderDecorator, RouterDecorator],
+} satisfies Meta<typeof HomepageLaunchpad>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/web/src/components/HomepageLaunchpad.tsx
+++ b/web/src/components/HomepageLaunchpad.tsx
@@ -1,0 +1,141 @@
+import { Link, LinkProps } from "@tanstack/react-router";
+import clsx from "clsx";
+import {
+  Cog,
+  ListCheck,
+  MapIcon,
+  QrCode,
+  Trophy,
+  UsersRound,
+} from "lucide-react";
+import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import { useQRDrawerContext } from "@/contexts/useQRDrawerContext.ts";
+
+const GridItem = ({
+  title,
+  link,
+  onClick,
+  icon,
+  color,
+  style,
+  textStyle,
+}: GridElement) => {
+  const content = (
+    <div
+      className={clsx(
+        "group flex items-center justify-center p-4 text-center shadow hover:shadow-md",
+        color === "tertiary" ? `bg-tertiary` : `bg-secondary`,
+        style,
+      )}
+    >
+      {icon}
+      <span className={clsx("text-lg font-medium text-gray-800", textStyle)}>
+        {title}
+      </span>
+    </div>
+  );
+
+  if (link) return <Link to={link}>{content}</Link>;
+  return (
+    <button onClick={onClick} className="w-full cursor-pointer">
+      {content}
+    </button>
+  );
+};
+
+type GridElementBase = {
+  title: string;
+  icon: ReactNode;
+  color: "secondary" | "tertiary";
+  style: string;
+  textStyle?: string;
+};
+
+type GridElementLink = GridElementBase & {
+  link: LinkProps["to"];
+  onClick?: undefined;
+};
+type GridElementButton = GridElementBase & {
+  onClick: () => void;
+  link?: undefined;
+};
+
+type GridElement = GridElementLink | GridElementButton;
+
+const HomepageLaunchpad = () => {
+  const [, setQRCodeDrawerOpen] = useQRDrawerContext();
+  const { t } = useTranslation();
+
+  const gridElements: GridElement[] = [
+    {
+      title: t("artists"),
+      link: "/artists",
+      icon: <UsersRound className="mb-2 h-12 w-12 text-gray-800" />,
+      color: "secondary",
+      style: "rounded-tl-2xl flex-col",
+      textStyle: "mt-2",
+    },
+    {
+      title: t("map"),
+      link: "/map",
+      icon: <MapIcon className="mb-2 h-12 w-12 text-gray-800" />,
+      color: "secondary",
+      style: "rounded-tr-2xl flex-col",
+      textStyle: "mt-2",
+    },
+    {
+      title: t("reward.pageTitle"),
+      link: "/reward",
+      icon: <Trophy className="mb-2 h-12 w-12 text-gray-800" />,
+      color: "secondary",
+      style: "rounded-bl-2xl flex-col",
+      textStyle: "mt-2",
+    },
+    {
+      title: t("qrcode"),
+      onClick: () => setQRCodeDrawerOpen(true),
+      icon: <QrCode className="mb-2 h-12 w-12 text-gray-800" />,
+      color: "tertiary",
+      style: "rounded-br-2xl flex-col",
+      textStyle: "mt-2",
+    },
+  ];
+
+  const secondGridElements: GridElement[] = [
+    {
+      title: t("rules"),
+      link: "/rules",
+      icon: <ListCheck className="h-6 w-6 text-black" />,
+      color: "secondary",
+      style: "rounded-l-2xl flex-row justify-center content-center",
+      textStyle: "ml-2",
+    },
+    {
+      title: t("settings.title"),
+      link: "/settings",
+      icon: <Cog className="h-6 w-6 text-black" />,
+      color: "secondary",
+      style: "rounded-r-2xl flex-row justify-center",
+      textStyle: "ml-2",
+    },
+  ];
+
+  return (
+    <>
+      <div className={"mb-4 grid grid-cols-2 gap-1"}>
+        {gridElements.map((element) => (
+          <GridItem key={element.title} {...element} />
+        ))}
+      </div>
+      <div className={"mb-4 grid grid-cols-2 gap-1"}>
+        {secondGridElements.map((element) => (
+          <GridItem key={element.title} {...element} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default HomepageLaunchpad;

--- a/web/src/components/Intro.tsx
+++ b/web/src/components/Intro.tsx
@@ -1,14 +1,7 @@
-import {
-  Dices,
-  QrCode,
-  Repeat,
-  Sparkles,
-  TicketCheck,
-  Users,
-} from "lucide-react";
-import { useTranslation } from "react-i18next";
+import { QrCode, TicketCheck } from "lucide-react";
+import { Trans, useTranslation } from "react-i18next";
 
-import { standardRewardMinStampsRequirement } from "@/lib/consts.ts";
+import { standardRewardMinStampsRequirement } from "@/lib/consts";
 
 const Intro = () => {
   const { t } = useTranslation();
@@ -19,32 +12,23 @@ const Intro = () => {
       </div>
       <ul className={"space-y-2 py-2"}>
         <li className={"flex items-center"}>
-          <Users size={36} className={"mr-2 shrink-0"} />
-          <span>{t("rally.1")}</span>
-        </li>
-        <li className={"flex items-center"}>
           <QrCode size={36} className={"mr-2 shrink-0"} />
-          <span>{t("rally.2")}</span>
+          <span>{t("rally.1")}</span>
         </li>
         <li className={"flex items-center"}>
           <TicketCheck size={36} className={"mr-2 shrink-0"} />
           <span>
-            {t("rally.3", {
-              minimumStampsCount: standardRewardMinStampsRequirement,
-            })}
+            <Trans
+              t={t}
+              i18nKey="rally.2"
+              components={{
+                1: <strong />,
+              }}
+              values={{
+                minimumStampsCount: standardRewardMinStampsRequirement,
+              }}
+            />
           </span>
-        </li>
-        <li className={"flex items-center"}>
-          <Sparkles size={36} className={"mr-2 shrink-0"} />
-          <span>{t("rally.4")}</span>
-        </li>
-        <li className={"flex items-center"}>
-          <Dices size={36} className={"mr-2 shrink-0"} />
-          <span>{t("rally.5")}</span>
-        </li>
-        <li className={"flex items-center"}>
-          <Repeat size={36} className={"mr-2 shrink-0"} />
-          <span>{t("rally.6")}</span>
         </li>
       </ul>
     </div>

--- a/web/src/components/routes/rallyists/RallyistsHomepage.stories.tsx
+++ b/web/src/components/routes/rallyists/RallyistsHomepage.stories.tsx
@@ -14,8 +14,8 @@ const meta = {
   component: RallyistsHomepage,
   decorators: [
     TanStackQueryDecorator,
-    RouterDecorator,
     QRDrawerContextProviderDecorator,
+    RouterDecorator,
   ],
 } satisfies Meta<typeof RallyistsHomepage>;
 

--- a/web/src/components/routes/rallyists/RallyistsHomepage.tsx
+++ b/web/src/components/routes/rallyists/RallyistsHomepage.tsx
@@ -1,12 +1,9 @@
-import { useTranslation } from "react-i18next";
-
 import type { StampWithId } from "@vtube-stamp-rally/shared-lib/models/Stamp.ts";
 import type { SubmissionWithId } from "@vtube-stamp-rally/shared-lib/models/Submission.ts";
 
 import Logo from "@/assets/logo.png";
+import HomepageLaunchpad from "@/components/HomepageLaunchpad.tsx";
 import Intro from "@/components/Intro.tsx";
-import { ButtonLink } from "@/components/controls/ButtonLink.tsx";
-import QRCodeLink from "@/components/controls/QRCodeLink.tsx";
 
 type RallyistsHomepageProps = {
   stamps?: StampWithId[];
@@ -17,8 +14,6 @@ const RallyistsHomepage = ({
   stamps = [],
   submissions = [],
 }: RallyistsHomepageProps) => {
-  const { t } = useTranslation();
-
   const showIntro =
     stamps.length === 0 && (!submissions || submissions.length === 0);
 
@@ -27,17 +22,9 @@ const RallyistsHomepage = ({
       <img src={Logo} alt="logo" className={"w-80"} />
 
       {showIntro && <Intro />}
-
-      <ButtonLink href="/artists">{t("artistList")}</ButtonLink>
-      <ButtonLink href="/reward">{t("reward.pageTitle")}</ButtonLink>
-      <ButtonLink href="/map">{t("map")}</ButtonLink>
-      <ButtonLink href="/rules" size="medium">
-        {t("rules")}
-      </ButtonLink>
-      <ButtonLink href="/settings" size="medium">
-        {t("settings.title")}
-      </ButtonLink>
-      <QRCodeLink size="medium" />
+      <div className={"mt-4 w-80"}>
+        <HomepageLaunchpad />
+      </div>
     </div>
   );
 };

--- a/web/src/components/routes/rallyists/Rules.test.tsx
+++ b/web/src/components/routes/rallyists/Rules.test.tsx
@@ -16,7 +16,7 @@ describe("Rallyists Rules", () => {
 
     const texts = lists.map((list) => list.querySelectorAll("li"));
 
-    expect(texts[0].length).toBe(6);
+    expect(texts[0].length).toBe(2);
 
     expect(texts[1].length).toBe(9);
   });

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -328,7 +328,7 @@
   },
   "qrcode": "QR Code",
   "rally": {
-    "1": "Get a stamp by making a purchase (minimum 2€) from one of the 16 artists participating",
+    "1": "Get a stamp by making a purchase (minimum 2€) from one of the 16 participating artists",
     "2": "Once <1>{{minimumStampsCount}} stamps</1> collected, head over to Sedeto's booth to get a reward!",
     "welcome": "Welcome to the Rally!"
   },

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -329,7 +329,7 @@
   "qrcode": "QR Code",
   "rally": {
     "1": "Get a stamp by making a purchase (minimum 2€) from one of the 16 participating artists",
-    "2": "Once <1>{{minimumStampsCount}} stamps</1> collected, head over to Sedeto's booth to get a reward!",
+    "2": "Once <1>{{minimumStampsCount}} stamps</1> are collected, head over to Sedeto's booth to get a reward!",
     "welcome": "Welcome to the Rally!"
   },
   "redeemedSubmissions": "Redeemed submissions",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -328,12 +328,8 @@
   },
   "qrcode": "QR Code",
   "rally": {
-    "1": "16 artists take part in this rally around VTubers",
-    "2": "After making a purchase (minimum 2€) from a participant booth, scan the QR code to get a stamp",
-    "3": "Once you've collected {{minimumStampsCount}} stamps and visited both halls, head over to Sedeto's booth to get a reward!",
-    "4": "This year, try to win a holographic card by getting all the stamps!",
-    "5": "Once you get your reward, enter the draw to win a shikishi from Sedeto!",
-    "6": "You can replay as many times as you like while rewards last!",
+    "1": "Get a stamp by making a purchase (minimum 2€) from one of the 16 artists participating",
+    "2": "Once <1>{{minimumStampsCount}} stamps</1> collected, head over to Sedeto's booth to get a reward!",
     "welcome": "Welcome to the Rally!"
   },
   "redeemedSubmissions": "Redeemed submissions",

--- a/web/src/i18n/fr.json
+++ b/web/src/i18n/fr.json
@@ -401,7 +401,7 @@
   },
   "scanThisQR": "Scannez ce QR pour récupérer le tampon !",
   "settings": {
-    "title": "Paramètres",
+    "title": "Réglages",
     "usernameEmpty": "Votre nom d'utilisateur ne peut pas être vide",
     "usernameTooLong": "Votre nom d'utilisateur ne peut pas faire plus de 50 caractères",
     "usernameUpdateFailed": "Le changement de nom d'utilisateur a échoué",

--- a/web/src/i18n/fr.json
+++ b/web/src/i18n/fr.json
@@ -328,12 +328,8 @@
   },
   "qrcode": "QR Code",
   "rally": {
-    "1": "16 artistes participent à ce rally autour des VTubers",
-    "2": "Après un achat (minimum 2€) chez un stand participant, scannez le tampon QR Code",
-    "3": "Une fois {{minimumStampsCount}} tampons obtenus en ayant visité les deux halls, rendez-vous au stand de Sedeto pour récupérer une récompense !",
-    "4": "Cette année, tentez votre chance pour une carte holographique en obtenant tous les tampons !",
-    "5": "Après avoir récupéré une récompense, participez au concours pour gagner un shikishi de Sedeto !",
-    "6": "Vous pouvez rejouer autant de fois que vous le souhaitez ! Dans la limite des stocks disponibles et dans la bonne humeur",
+    "1": "Obtenez un tampon en faisant un achat (minimum 2€) chez un des 16 artistes participant",
+    "2": "Une fois <1>{{minimumStampsCount}} tampons</1> obtenus, rendez-vous au stand de Sedeto pour récupérer une récompense !",
     "welcome": "Bienvenue sur le Rally !"
   },
   "redeemedSubmissions": "Soumissions déjà validées",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a unified launchpad with quick-access tiles (Artists, Map, Rewards, Scanner, Rules, Settings), responsive layout and QR scanner integration.

- Refactor
  - Rallyists homepage now uses the new launchpad instead of individual buttons, streamlining navigation.

- Documentation
  - Added Storybook story for the launchpad and adjusted decorator execution order.

- UI / Content
  - Simplified rally instructions to concise, stamp-focused guidance and reduced intro icons.

- Localization
  - French label changed ("Paramètres" → "Réglages") and English rally text updated.

- Tests
  - Updated test expectations for the shortened rally instruction list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->